### PR TITLE
Update Dockerfile to Allow Command Line Execution

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -24,4 +24,4 @@ VOLUME /app/data
 
 WORKDIR /app/run/bin
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]


### PR DESCRIPTION
See https://stackoverflow.com/a/62313159 

Adding -c allows for a one liner: `docker run --rm -it -v <path>:/data -u $UID:$GID addy90/map-matching-2 ./map_matching_2 --match -i ...`

Which will be useful on unsupported platforms like MacOS